### PR TITLE
Fix #44 duration issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/portfolio:v7.2.0
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/portfolio:v7.2.1
 
   s3_deploy:
     needs: push_to_registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Personal Portfolio project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [7.2.1] (2024-05-24)
+
+### Fixed
+
+- Special thanks to @oliverphardman, for finding and fixing the Date in the Experience section displaying NaN error for Firefox or other browsers using the SpiderMonkey JS engine.
+
 ## [7.2.0] (2024-04-29)
 
 ### Added
@@ -253,6 +259,7 @@ All notable changes to the Personal Portfolio project will be documented in this
 - Updated `deploy.yml` file to follow semantic versioning.
 - Updated `README.md`.
 
+[7.2.1]: https://github.com/AbdulMiah/Portfolio/releases/tag/v7.2.1
 [7.2.0]: https://github.com/AbdulMiah/Portfolio/releases/tag/v7.2.0
 [7.0.1]: https://github.com/AbdulMiah/Portfolio/releases/tag/v7.0.1
 [7.0.0]: https://github.com/AbdulMiah/Portfolio/releases/tag/v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Personal Portfolio project will be documented in this
 
 ### Fixed
 
-- Special thanks to @oliverphardman, for finding and fixing the Date in the Experience section displaying NaN error for Firefox or other browsers using the SpiderMonkey JS engine.
+- Special thanks to [https://github.com/oliverphardman](@oliverphardman), for finding and fixing the Date in the Experience section displaying NaN error for Firefox or other browsers using the SpiderMonkey JS engine.
 
 ## [7.2.0] (2024-04-29)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "7.0.0",
+  "version": "7.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "7.0.0",
+      "version": "7.2.1",
       "dependencies": {
         "@emailjs/browser": "^3.11.0",
         "@emotion/react": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfolio",
   "private": true,
-  "version": "7.2.0",
+  "version": "7.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ function App() {
         />
         {projects.map((project, index) => (
           <Route
+            key={index}
             path={`/project/${project.id}`}
             element={
               <ProjectDetails

--- a/src/pages/experience/ExperienceCard.tsx
+++ b/src/pages/experience/ExperienceCard.tsx
@@ -11,12 +11,27 @@ type ExperienceCardProp = {
   experience: Experience;
 };
 
+const parseShortMonthYear = (
+  dateStr: string
+): Date => {
+  const [month, yearStr] = dateStr.split(" ");
+  const months: string[] = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const monthIndex = months.indexOf(month);
+  if (monthIndex === -1) {
+      throw new Error("Invalid month");
+  }
+
+  const year = parseInt(yearStr);
+
+  return new Date(year, monthIndex);
+}
+
 const calculateTimeDifference = (
   startDate: string,
   endDate: string
 ): string => {
-  const start = new Date(startDate);
-  const end = endDate === "Present" ? new Date() : new Date(endDate);
+  const start = parseShortMonthYear(startDate);
+  const end = endDate === "Present" ? new Date() : parseShortMonthYear(endDate);
 
   const diffInMonths =
     (end.getFullYear() - start.getFullYear()) * 12 +


### PR DESCRIPTION
As mentioned in #44 attempting to view the portfolio on Firefox or other browsers using the SpiderMonkey JS engine results in a NaN error being displayed.

This occurs because SpiderMonkey does not support the "short date, followed by year" datestring. For example, in Blink/Chrome and Node.js, this is recognised as a valid Date constructor parameter:
`new Date("Jun 2022")`

But in SpiderMonkey, this throws an `Invalid Date` error.

The `parseShortMonthYear` function takes in this format and instantiates a Date object by identifying what month index the string represents (i.e. Jan = 0, Feb = 1) and splitting the year into a separate variable, then providing these to a Date constructor to return a valid object.

Also fixed a minor issue which caused a warning that a key parameter was not specified in the routes.